### PR TITLE
Set `--server-name` to something PyPI-specific

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: /bin/go-camo --socket-listen=/var/run/cabotage/cabotage.sock
+web: /bin/go-camo --socket-listen=/var/run/cabotage/cabotage.sock --server-name=https://github.com/pypi/camo


### PR DESCRIPTION
This has the effect of setting the `User-Agent` header: https://github.com/pypi/camo/blob/075858e7f9665c1a065bed298ce5ff7c796d4e5c/pkg/camo/proxy.go#L162

